### PR TITLE
大文字小文字の混在処理を改善 #3

### DIFF
--- a/addon/doc/ja/readme.md
+++ b/addon/doc/ja/readme.md
@@ -98,6 +98,10 @@ Copyright (C) 2022 Kazto Kitabatake, ACT Laboratory All rights reserved.
 
 ## 更新履歴
 
+### 2022/XX/XX Version 1.X.X
+
+1. 大文字を含む文字列を読み上げる際、特定の場合に不要な空白が空いてしまう問題を、更に修正しました。
+
 ### 2022/09/23 Version 1.0.1
 
 1. NVDAの設定で[サポートされている場合自動的に言語を切り替える]が有効な場合に、アドオンの組み込み時に警告メッセージを表示するようにしました。

--- a/addon/globalPlugins/ERE/__init__.py
+++ b/addon/globalPlugins/ERE/__init__.py
@@ -37,7 +37,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			self.autoUpdateChecker = updater.AutoUpdateChecker()
 			self.autoUpdateChecker.autoUpdateCheck()
 		self._setupMenu()
-		self._setup()
+		if self.getStateSetting():
+			self._setup()
 		t = threading.Thread(target=self._checkAutoLanguageSwitchingState, daemon=True)
 		t.start()
 
@@ -54,13 +55,13 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def _setup(self):
 		if hasattr(speech, "speech"):
-			processText_original = speech.speech.processText
+			self.processText_original = speech.speech.processText
 		else:
-			processText_original = speech.processText
+			self.processText_original = speech.processText
 		c = EnglishToKanaConverter()
 
 		def processText(locale, text, symbolLevel):
-			text = processText_original(locale, text, symbolLevel)
+			text = self.processText_original(locale, text, symbolLevel)
 			if locale.startswith("ja") and self.getStateSetting():
 				text = c.process(text)
 			return text
@@ -68,6 +69,12 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			speech.speech.processText = processText
 		else:
 			speech.processText = processText
+
+	def _unsetup(self):
+		if hasattr(speech, "speech"):
+			speech.speech.processText = self.processText_original
+		else:
+			speech.processText = self.processText_original
 
 	def _setupMenu(self):
 		self.rootMenu = wx.Menu()
@@ -113,6 +120,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def setStateSetting(self, val):
 		config.conf["ERE_global"]["enable"] = val
+		if val:
+			self._setup()
+		else:
+			self._unsetup()
 
 	def stateToggleString(self):
 		return _("Disable English Reading Enhancer") if self.getStateSetting() is True else _("Enable English Reading Enhancer")

--- a/addon/globalPlugins/ERE/__init__.py
+++ b/addon/globalPlugins/ERE/__init__.py
@@ -9,6 +9,8 @@ import threading
 import time
 import wx
 import speech
+import speechDictHandler
+from copy import deepcopy
 from logHandler import log
 from .constants import *
 from . import updater
@@ -69,12 +71,26 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			speech.speech.processText = processText
 		else:
 			speech.processText = processText
+		# modify builtin speech dicts
+		unusedEntries = []
+		unusedPatterns = (
+			"([a-z])([A-Z])",
+			"([A-Z])([A-Z][a-z])",
+		)
+		for entry in speechDictHandler.dictionaries["builtin"]:
+			if entry.pattern in unusedPatterns:
+				unusedEntries.append(entry)
+		self.builtinDict_original = deepcopy(speechDictHandler.dictionaries["builtin"])
+		for entry in unusedEntries:
+			index = speechDictHandler.dictionaries["builtin"].index(entry)
+			del speechDictHandler.dictionaries["builtin"][index]
 
 	def _unsetup(self):
 		if hasattr(speech, "speech"):
 			speech.speech.processText = self.processText_original
 		else:
 			speech.processText = self.processText_original
+		speechDictHandler.dictionaries["builtin"] = self.builtinDict_original
 
 	def _setupMenu(self):
 		self.rootMenu = wx.Menu()


### PR DESCRIPTION
英語仮名変換が有効な間、NVDA組み込みの辞書に登録された、大文字・小文字が混在する文字列を処理するためのエントリーを一時的に削除するようにした。
弊害があれば別の方法を検討する。