### PR TITLE
`processText` を NVDA 2024.3 以降向けに修正

### DIFF
--- a/addon/globalPlugins/ERE/__init__.py
+++ b/addon/globalPlugins/ERE/__init__.py
@@ -64,8 +64,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			self.processText_original = speech.processText
 		c = EnglishToKanaConverter()
 
-		def processText(locale, text, symbolLevel):
-			text = self.processText_original(locale, text, symbolLevel)
+		def processText(locale, text, symbolLevel, **kwargs):
+			text = self.processText_original(locale, text, symbolLevel, **kwargs)
 			if locale.startswith("ja") and self.getStateSetting():
 				text = c.process(text)
 			return text


### PR DESCRIPTION
NVDA 2024.3 で `speech.processText` に引数が増えたようで、現状のコードではエラーになってしまい、全く読み上げが行われなくなってしまいました。
そのため、これを修正しています。
一応 NVDA 2024.2JP および 2024.3JP のベータ版でうまく動作していることは確認しています。
