### PR TITLE
NVDA 2025.1の仕様変更に対応

### DIFF
--- a/addon/globalPlugins/ERE/__init__.py
+++ b/addon/globalPlugins/ERE/__init__.py
@@ -14,6 +14,7 @@ from copy import deepcopy
 from logHandler import log
 from .constants import *
 from . import updater
+from . import compatibilityUtil
 from ._englishToKanaConverter.englishToKanaConverter import EnglishToKanaConverter
 from scriptHandler import script
 
@@ -48,7 +49,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def _checkAutoLanguageSwitchingState(self):
 		if self.getStateSetting() and config.conf["speech"]["autoLanguageSwitching"]:
-			gui.messageBox(_("Automatic Language switching is enabled. English Reading Enhancer may not work correctly. To use this add-on, we recommend to disable this functionality."), _("Warning"))
+			compatibilityUtil.messageBox(_("Automatic Language switching is enabled. English Reading Enhancer may not work correctly. To use this add-on, we recommend to disable this functionality."), _("Warning"))
 
 	def terminate(self):
 		super(GlobalPlugin, self).terminate()
@@ -121,7 +122,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self.setUpdateCheckSetting(changed)
 		msg = _("Updates will be checked automatically when launching NVDA.") if changed is True else _("Updates will not be checked when launching NVDA.")
 		self.updateCheckToggleItem.SetItemLabel(self.updateCheckToggleString())
-		gui.messageBox(msg, _("Settings changed"))
+		compatibilityUtil.messageBox(msg, _("Settings changed"))
 
 	def performUpdateCheck(self, evt):
 		updater.AutoUpdateChecker().autoUpdateCheck(mode=updater.MANUAL)
@@ -137,7 +138,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self.setStateSetting(changed)
 		msg = _("English Reading Enhancer has been enabled.") if changed is True else _("English Reading Enhancer has been disabled.")
 		self.stateToggleItem.SetItemLabel(self.stateToggleString())
-		gui.messageBox(msg, _("Settings changed"))
+		compatibilityUtil.messageBox(msg, _("Settings changed"))
 		if changed:
 			t = threading.Thread(target=self._checkAutoLanguageSwitchingState, daemon=True)
 			t.start()
@@ -161,7 +162,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		if gui.message.isModalMessageBoxActive():
 			return
 		if not config.conf["ERE_global"]["accessToken"]:
-			gui.messageBox(_("Before using this feature, please set your GitHub Access Token."), _("Error"))
+			compatibilityUtil.messageBox(_("Before using this feature, please set your GitHub Access Token."), _("Error"))
 			return
 		from .dialogs import reportMisreadingsDialog
 		gui.mainFrame.prePopup()
@@ -183,7 +184,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		)
 		for label, field in z:
 			if not field:
-				gui.messageBox(_("%s is not entered.") % label, _("Error"), wx.ICON_ERROR)
+				compatibilityUtil.messageBox(_("%s is not entered.") % label, _("Error"))
 				return
 		# end validation
 		from .constants import addonVersion
@@ -216,9 +217,9 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		util = GhUtil(config.conf["ERE_global"]["accessToken"])
 		result = util.createIssue(GH_REPO_OWNER, GH_REPO_NAME, title, body)
 		if not result:
-			gui.messageBox(_("Failed to send a report."), _("Error"), wx.ICON_ERROR)
+			compatibilityUtil.messageBox(_("Failed to send a report."), _("Error"))
 			return
-		gui.messageBox(_("Report sent."), _("Success"))
+		compatibilityUtil.messageBox(_("Report sent."), _("Success"))
 
 	# define script
 	@script(description=_("Report Misreadings"), gesture="kb:nvda+control+shift+e")
@@ -248,7 +249,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			util = GhUtil(token)
 			if not util.isActive():
 				# 認証されていない
-				gui.messageBox(_("GitHub Access Token is invalid."), _("Error"), wx.ICON_ERROR)
+				compatibilityUtil.messageBox(_("GitHub Access Token is invalid."), _("Error"))
 				continue
 			break
 		config.conf["ERE_global"]["accessToken"] = token

--- a/addon/globalPlugins/ERE/compatibilityUtil.py
+++ b/addon/globalPlugins/ERE/compatibilityUtil.py
@@ -1,0 +1,12 @@
+import gui
+import wx
+import versionInfo
+
+def isCompatibleWith2025():
+    return versionInfo.version_year >= 2025
+
+def messageBox(message: str, title: str, parent: wx.Window | None=None):
+    if isCompatibleWith2025():
+        gui.message.MessageDialog.alert(message, title, parent)
+    else:
+        gui.messageBox(message, title, style=wx.CENTER, parent=parent)

--- a/addon/globalPlugins/ERE/dialogs/reportMisreadingsDialog.py
+++ b/addon/globalPlugins/ERE/dialogs/reportMisreadingsDialog.py
@@ -1,6 +1,7 @@
 # -*- coding: UTF-8 -*-
 
 import wx
+from .. import compatibilityUtil
 
 # 翻訳が当たるようにする
 try:
@@ -67,7 +68,7 @@ class ReportMisreadingsDialog(wx.Dialog):
 		for label, field in z:
 			if not field:
 				import gui
-				gui.messageBox(_("%s is not entered.") % label, _("Error"), wx.ICON_ERROR, self)
+				compatibilityUtil.messageBox(_("%s is not entered.") % label, _("Error"), self)
 				return
 		# end validation
 		event.Skip()

--- a/buildVars.py
+++ b/buildVars.py
@@ -41,7 +41,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion": "2019.3",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2024.1",
+	"addon_lastTestedNVDAVersion": "2025.1",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!


### PR DESCRIPTION
メッセージボックスに`style=wx.ICON_ERROR`を指定する方法がなくなってしまったと思われるので、`style`の指定は削除。