### PR TITLE
Refactor speech processing to use extension points

### DIFF
--- a/addon/globalPlugins/ERE/__init__.py
+++ b/addon/globalPlugins/ERE/__init__.py
@@ -47,12 +47,12 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		t.start()
 
 	def _initializeExtensionPoints(self):
-		"""Initialize extension points and register handlers."""
-		# Register default dictionary pattern removals
+		"""拡張ポイントを初期化し、ハンドラを登録する。"""
+		# デフォルトの辞書パターン削除を登録
 		speechHook.registerDefaultPatternRemovals()
 
-		# Register the English to Kana processor with the pre-process extension point
-		# This ensures text is converted before NVDA's standard processing
+		# EnglishToKanaプロセッサを前処理拡張ポイントに登録
+		# これによりNVDAの標準処理の前にテキストが変換される
 		self._textProcessor = getEnglishToKanaProcessor()
 		extensionPoints.textProcessing.preProcessText.register(self._textProcessor)
 
@@ -63,7 +63,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def terminate(self):
 		super(GlobalPlugin, self).terminate()
 		self._fullUnsetup()
-		# Unregister extension point handlers
+		# 拡張ポイントハンドラの登録を解除
 		extensionPoints.textProcessing.preProcessText.unregister(self._textProcessor)
 		try:
 			gui.mainFrame.sysTrayIcon.menu.Remove(self.rootMenuItem)
@@ -71,29 +71,29 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			pass
 
 	def _setup(self):
-		"""Enable text processing using extension points."""
+		"""拡張ポイントを使用してテキスト処理を有効にする。"""
 		manager = speechHook.getManager()
 
-		# Install the speech hook if not already installed
+		# まだインストールされていない場合は音声フックをインストール
 		if not manager.isInstalled:
 			manager.install()
 			manager.applyDictionaryModifications()
 
-		# Enable text processing
+		# テキスト処理を有効にする
 		manager.setEnabled(True)
 
 	def _unsetup(self):
-		"""Disable text processing and restore original state."""
+		"""テキスト処理を無効にし、元の状態を復元する。"""
 		manager = speechHook.getManager()
 
-		# Disable text processing
+		# テキスト処理を無効にする
 		manager.setEnabled(False)
 
-		# Only uninstall and restore if we're completely shutting down
-		# (this is handled in terminate)
+		# 完全にシャットダウンする場合のみアンインストールと復元を行う
+		# （これはterminateで処理される）
 
 	def _fullUnsetup(self):
-		"""Fully uninstall the speech hook (used during terminate)."""
+		"""音声フックを完全にアンインストールする（terminate時に使用）。"""
 		manager = speechHook.getManager()
 		manager.setEnabled(False)
 		manager.restoreDictionaryModifications()

--- a/addon/globalPlugins/ERE/extensionPoints.py
+++ b/addon/globalPlugins/ERE/extensionPoints.py
@@ -1,14 +1,14 @@
 # coding: UTF-8
 """
-Extension Points Module for English Reading Enhancer
+English Reading Enhancer用の拡張ポイントモジュール
 
-This module provides extension point infrastructure for text processing,
-allowing handlers to be registered and called in a clean, decoupled manner
-instead of using function overrides/monkey-patching.
+このモジュールは、関数オーバーライド/モンキーパッチの代わりに、
+ハンドラを登録して呼び出すためのクリーンで疎結合な
+テキスト処理用の拡張ポイント基盤を提供します。
 
-Extension point types:
-- Filter: Allows handlers to modify data passing through
-- Action: Notifies handlers when something happens (no return value)
+拡張ポイントの種類:
+- Filter: ハンドラがデータを変更できるようにする
+- Action: 何かが起きた時にハンドラに通知する（戻り値なし）
 """
 
 from __future__ import unicode_literals
@@ -17,41 +17,41 @@ from logHandler import log
 
 
 class HandlerRegistrar:
-	"""Base class for managing handler registration."""
+	"""ハンドラ登録を管理する基底クラス。"""
 
 	def __init__(self):
 		self._handlers: List[Callable] = []
 
 	def register(self, handler: Callable) -> None:
-		"""Register a handler function."""
+		"""ハンドラ関数を登録する。"""
 		if handler not in self._handlers:
 			self._handlers.append(handler)
 			log.debug(f"Handler registered: {handler.__name__ if hasattr(handler, '__name__') else handler}")
 
 	def unregister(self, handler: Callable) -> None:
-		"""Unregister a handler function."""
+		"""ハンドラ関数の登録を解除する。"""
 		if handler in self._handlers:
 			self._handlers.remove(handler)
 			log.debug(f"Handler unregistered: {handler.__name__ if hasattr(handler, '__name__') else handler}")
 
 	def isRegistered(self, handler: Callable) -> bool:
-		"""Check if a handler is registered."""
+		"""ハンドラが登録されているか確認する。"""
 		return handler in self._handlers
 
 	@property
 	def handlers(self) -> List[Callable]:
-		"""Get list of registered handlers (copy)."""
+		"""登録されているハンドラのリスト（コピー）を取得する。"""
 		return self._handlers.copy()
 
 
 class Filter(HandlerRegistrar):
 	"""
-	Extension point that allows handlers to filter/modify data.
+	ハンドラがデータをフィルタ/変更できる拡張ポイント。
 
-	Handlers are called in registration order, each receiving the output
-	of the previous handler. This creates a processing pipeline.
+	ハンドラは登録順に呼び出され、それぞれが前のハンドラの出力を受け取る。
+	これにより処理パイプラインが作成される。
 
-	Usage:
+	使用例:
 		textFilter = Filter()
 		textFilter.register(my_handler)
 		result = textFilter.apply(initial_value, locale="ja")
@@ -59,14 +59,14 @@ class Filter(HandlerRegistrar):
 
 	def apply(self, value: Any, **kwargs) -> Any:
 		"""
-		Apply all registered handlers to the value.
+		登録されているすべてのハンドラを値に適用する。
 
-		Args:
-			value: The initial value to be filtered
-			**kwargs: Additional keyword arguments passed to all handlers
+		引数:
+			value: フィルタリングする初期値
+			**kwargs: すべてのハンドラに渡される追加のキーワード引数
 
-		Returns:
-			The filtered value after all handlers have processed it
+		戻り値:
+			すべてのハンドラが処理した後のフィルタリングされた値
 		"""
 		for handler in self._handlers:
 			try:
@@ -78,12 +78,12 @@ class Filter(HandlerRegistrar):
 
 class Action(HandlerRegistrar):
 	"""
-	Extension point that notifies handlers when an event occurs.
+	イベント発生時にハンドラに通知する拡張ポイント。
 
-	Unlike Filter, handlers don't return values - they just receive
-	notification that something happened.
+	Filterとは異なり、ハンドラは値を返さない。
+	何かが起きたという通知を受け取るだけ。
 
-	Usage:
+	使用例:
 		onEnabled = Action()
 		onEnabled.register(my_handler)
 		onEnabled.notify(some_data="value")
@@ -91,10 +91,10 @@ class Action(HandlerRegistrar):
 
 	def notify(self, **kwargs) -> None:
 		"""
-		Notify all registered handlers.
+		登録されているすべてのハンドラに通知する。
 
-		Args:
-			**kwargs: Keyword arguments passed to all handlers
+		引数:
+			**kwargs: すべてのハンドラに渡されるキーワード引数
 		"""
 		for handler in self._handlers:
 			try:
@@ -105,32 +105,31 @@ class Action(HandlerRegistrar):
 
 class TextProcessingExtensionPoint:
 	"""
-	Extension point for text processing before speech synthesis.
+	音声合成前のテキスト処理用の拡張ポイント。
 
-	This replaces the previous monkey-patching approach with a clean
-	extension point that allows text processors to be registered
-	and applied in sequence.
+	以前のモンキーパッチ方式を、テキストプロセッサを登録して
+	順番に適用できるクリーンな拡張ポイントに置き換える。
 	"""
 
-	# Filter applied before NVDA's processText
+	# NVDAのprocessTextの前に適用されるフィルタ
 	preProcessText = Filter()
 
-	# Filter applied after NVDA's processText
+	# NVDAのprocessTextの後に適用されるフィルタ
 	postProcessText = Filter()
 
-	# Action triggered when processing is enabled
+	# 処理が有効になった時にトリガーされるアクション
 	onEnabled = Action()
 
-	# Action triggered when processing is disabled
+	# 処理が無効になった時にトリガーされるアクション
 	onDisabled = Action()
 
 
 class SpeechDictModifier:
 	"""
-	Extension point for modifying speech dictionaries.
+	音声辞書を変更するための拡張ポイント。
 
-	Provides a clean interface for registering dictionary modifications
-	that can be applied/reverted without direct manipulation.
+	直接操作せずに適用/元に戻すことができる
+	辞書変更を登録するためのクリーンなインターフェースを提供する。
 	"""
 
 	def __init__(self):
@@ -138,32 +137,32 @@ class SpeechDictModifier:
 		self._originalState: Optional[Any] = None
 
 	def registerPatternRemoval(self, pattern: str) -> None:
-		"""Register a pattern to be removed from builtin dictionary."""
+		"""組み込み辞書から削除するパターンを登録する。"""
 		self._modifications.append({
 			'type': 'remove_pattern',
 			'pattern': pattern
 		})
 
 	def getModifications(self) -> List[dict]:
-		"""Get list of registered modifications."""
+		"""登録されている変更のリストを取得する。"""
 		return self._modifications.copy()
 
 	def setOriginalState(self, state: Any) -> None:
-		"""Store the original dictionary state for restoration."""
+		"""復元用に元の辞書状態を保存する。"""
 		self._originalState = state
 
 	def getOriginalState(self) -> Optional[Any]:
-		"""Get the stored original state."""
+		"""保存されている元の状態を取得する。"""
 		return self._originalState
 
 
-# Global extension point instances
+# グローバル拡張ポイントインスタンス
 textProcessing = TextProcessingExtensionPoint()
 speechDictModifier = SpeechDictModifier()
 
 
 def resetAll() -> None:
-	"""Reset all extension points (useful for testing or cleanup)."""
+	"""すべての拡張ポイントをリセットする（テストやクリーンアップに便利）。"""
 	textProcessing.preProcessText._handlers.clear()
 	textProcessing.postProcessText._handlers.clear()
 	textProcessing.onEnabled._handlers.clear()

--- a/addon/globalPlugins/ERE/extensionPoints.py
+++ b/addon/globalPlugins/ERE/extensionPoints.py
@@ -1,0 +1,172 @@
+# coding: UTF-8
+"""
+Extension Points Module for English Reading Enhancer
+
+This module provides extension point infrastructure for text processing,
+allowing handlers to be registered and called in a clean, decoupled manner
+instead of using function overrides/monkey-patching.
+
+Extension point types:
+- Filter: Allows handlers to modify data passing through
+- Action: Notifies handlers when something happens (no return value)
+"""
+
+from __future__ import unicode_literals
+from typing import Callable, List, Any, Optional
+from logHandler import log
+
+
+class HandlerRegistrar:
+	"""Base class for managing handler registration."""
+
+	def __init__(self):
+		self._handlers: List[Callable] = []
+
+	def register(self, handler: Callable) -> None:
+		"""Register a handler function."""
+		if handler not in self._handlers:
+			self._handlers.append(handler)
+			log.debug(f"Handler registered: {handler.__name__ if hasattr(handler, '__name__') else handler}")
+
+	def unregister(self, handler: Callable) -> None:
+		"""Unregister a handler function."""
+		if handler in self._handlers:
+			self._handlers.remove(handler)
+			log.debug(f"Handler unregistered: {handler.__name__ if hasattr(handler, '__name__') else handler}")
+
+	def isRegistered(self, handler: Callable) -> bool:
+		"""Check if a handler is registered."""
+		return handler in self._handlers
+
+	@property
+	def handlers(self) -> List[Callable]:
+		"""Get list of registered handlers (copy)."""
+		return self._handlers.copy()
+
+
+class Filter(HandlerRegistrar):
+	"""
+	Extension point that allows handlers to filter/modify data.
+
+	Handlers are called in registration order, each receiving the output
+	of the previous handler. This creates a processing pipeline.
+
+	Usage:
+		textFilter = Filter()
+		textFilter.register(my_handler)
+		result = textFilter.apply(initial_value, locale="ja")
+	"""
+
+	def apply(self, value: Any, **kwargs) -> Any:
+		"""
+		Apply all registered handlers to the value.
+
+		Args:
+			value: The initial value to be filtered
+			**kwargs: Additional keyword arguments passed to all handlers
+
+		Returns:
+			The filtered value after all handlers have processed it
+		"""
+		for handler in self._handlers:
+			try:
+				value = handler(value, **kwargs)
+			except Exception as e:
+				log.error(f"Error in filter handler {handler}: {e}")
+		return value
+
+
+class Action(HandlerRegistrar):
+	"""
+	Extension point that notifies handlers when an event occurs.
+
+	Unlike Filter, handlers don't return values - they just receive
+	notification that something happened.
+
+	Usage:
+		onEnabled = Action()
+		onEnabled.register(my_handler)
+		onEnabled.notify(some_data="value")
+	"""
+
+	def notify(self, **kwargs) -> None:
+		"""
+		Notify all registered handlers.
+
+		Args:
+			**kwargs: Keyword arguments passed to all handlers
+		"""
+		for handler in self._handlers:
+			try:
+				handler(**kwargs)
+			except Exception as e:
+				log.error(f"Error in action handler {handler}: {e}")
+
+
+class TextProcessingExtensionPoint:
+	"""
+	Extension point for text processing before speech synthesis.
+
+	This replaces the previous monkey-patching approach with a clean
+	extension point that allows text processors to be registered
+	and applied in sequence.
+	"""
+
+	# Filter applied before NVDA's processText
+	preProcessText = Filter()
+
+	# Filter applied after NVDA's processText
+	postProcessText = Filter()
+
+	# Action triggered when processing is enabled
+	onEnabled = Action()
+
+	# Action triggered when processing is disabled
+	onDisabled = Action()
+
+
+class SpeechDictModifier:
+	"""
+	Extension point for modifying speech dictionaries.
+
+	Provides a clean interface for registering dictionary modifications
+	that can be applied/reverted without direct manipulation.
+	"""
+
+	def __init__(self):
+		self._modifications: List[dict] = []
+		self._originalState: Optional[Any] = None
+
+	def registerPatternRemoval(self, pattern: str) -> None:
+		"""Register a pattern to be removed from builtin dictionary."""
+		self._modifications.append({
+			'type': 'remove_pattern',
+			'pattern': pattern
+		})
+
+	def getModifications(self) -> List[dict]:
+		"""Get list of registered modifications."""
+		return self._modifications.copy()
+
+	def setOriginalState(self, state: Any) -> None:
+		"""Store the original dictionary state for restoration."""
+		self._originalState = state
+
+	def getOriginalState(self) -> Optional[Any]:
+		"""Get the stored original state."""
+		return self._originalState
+
+
+# Global extension point instances
+textProcessing = TextProcessingExtensionPoint()
+speechDictModifier = SpeechDictModifier()
+
+
+def resetAll() -> None:
+	"""Reset all extension points (useful for testing or cleanup)."""
+	textProcessing.preProcessText._handlers.clear()
+	textProcessing.postProcessText._handlers.clear()
+	textProcessing.onEnabled._handlers.clear()
+	textProcessing.onDisabled._handlers.clear()
+	speechDictModifier._modifications.clear()
+	speechDictModifier._originalState = None

--- a/addon/globalPlugins/ERE/speechHook.py
+++ b/addon/globalPlugins/ERE/speechHook.py
@@ -1,0 +1,176 @@
+# coding: UTF-8
+"""
+Speech Hook Module for English Reading Enhancer
+
+This module manages the integration between NVDA's speech system and
+the extension point-based text processing pipeline.
+
+Instead of directly monkey-patching speech.processText, this module
+provides a clean interface that uses the extension point system.
+"""
+
+from __future__ import unicode_literals
+from copy import deepcopy
+from typing import Callable, Optional, Any, List
+import speech
+import speechDictHandler
+from logHandler import log
+from . import extensionPoints
+
+
+class SpeechHookManager:
+	"""
+	Manages the speech hook lifecycle.
+
+	This class handles:
+	- Installing/uninstalling the speech processText hook
+	- Managing speech dictionary modifications
+	- Coordinating with the extension point system
+	"""
+
+	def __init__(self):
+		self._originalProcessText: Optional[Callable] = None
+		self._originalBuiltinDict: Optional[Any] = None
+		self._isInstalled: bool = False
+		self._enabled: bool = False
+
+	@property
+	def isInstalled(self) -> bool:
+		"""Check if the speech hook is currently installed."""
+		return self._isInstalled
+
+	@property
+	def isEnabled(self) -> bool:
+		"""Check if text processing is enabled."""
+		return self._enabled
+
+	def setEnabled(self, enabled: bool) -> None:
+		"""Enable or disable text processing (without uninstalling hook)."""
+		self._enabled = enabled
+		if enabled:
+			extensionPoints.textProcessing.onEnabled.notify()
+		else:
+			extensionPoints.textProcessing.onDisabled.notify()
+
+	def install(self) -> None:
+		"""
+		Install the speech hook.
+
+		This replaces NVDA's processText with our wrapper that uses
+		the extension point system.
+		"""
+		if self._isInstalled:
+			log.debug("SpeechHookManager: Hook already installed")
+			return
+
+		# Store original processText
+		if hasattr(speech, "speech"):
+			self._originalProcessText = speech.speech.processText
+		else:
+			self._originalProcessText = speech.processText
+
+		# Create wrapper function
+		def processText(locale: str, text: str, symbolLevel, **kwargs) -> str:
+			# Apply pre-processing filters only if enabled
+			if self._enabled:
+				text = extensionPoints.textProcessing.preProcessText.apply(
+					text, locale=locale, symbolLevel=symbolLevel
+				)
+
+			# Call original NVDA processText
+			text = self._originalProcessText(locale, text, symbolLevel, **kwargs)
+
+			# Apply post-processing filters only if enabled
+			if self._enabled:
+				text = extensionPoints.textProcessing.postProcessText.apply(
+					text, locale=locale, symbolLevel=symbolLevel
+				)
+
+			return text
+
+		# Install the wrapper
+		if hasattr(speech, "speech"):
+			speech.speech.processText = processText
+		else:
+			speech.processText = processText
+
+		self._isInstalled = True
+		log.debug("SpeechHookManager: Hook installed")
+
+	def uninstall(self) -> None:
+		"""
+		Uninstall the speech hook.
+
+		This restores NVDA's original processText function.
+		"""
+		if not self._isInstalled:
+			log.debug("SpeechHookManager: Hook not installed")
+			return
+
+		if self._originalProcessText is not None:
+			if hasattr(speech, "speech"):
+				speech.speech.processText = self._originalProcessText
+			else:
+				speech.processText = self._originalProcessText
+
+		self._isInstalled = False
+		self._originalProcessText = None
+		log.debug("SpeechHookManager: Hook uninstalled")
+
+	def applyDictionaryModifications(self) -> None:
+		"""
+		Apply speech dictionary modifications based on registered patterns.
+		"""
+		modifications = extensionPoints.speechDictModifier.getModifications()
+		if not modifications:
+			return
+
+		# Store original state
+		self._originalBuiltinDict = deepcopy(speechDictHandler.dictionaries["builtin"])
+		extensionPoints.speechDictModifier.setOriginalState(self._originalBuiltinDict)
+
+		# Apply modifications
+		entriesToRemove: List[Any] = []
+		for mod in modifications:
+			if mod['type'] == 'remove_pattern':
+				for entry in speechDictHandler.dictionaries["builtin"]:
+					if entry.pattern == mod['pattern']:
+						entriesToRemove.append(entry)
+
+		for entry in entriesToRemove:
+			try:
+				index = speechDictHandler.dictionaries["builtin"].index(entry)
+				del speechDictHandler.dictionaries["builtin"][index]
+				log.debug(f"Removed dictionary pattern: {entry.pattern}")
+			except (ValueError, IndexError) as e:
+				log.warning(f"Could not remove dictionary pattern: {e}")
+
+	def restoreDictionaryModifications(self) -> None:
+		"""
+		Restore the original speech dictionary state.
+		"""
+		originalState = extensionPoints.speechDictModifier.getOriginalState()
+		if originalState is not None:
+			speechDictHandler.dictionaries["builtin"] = originalState
+			extensionPoints.speechDictModifier.setOriginalState(None)
+			log.debug("SpeechHookManager: Dictionary restored")
+
+
+# Global singleton instance
+_manager: Optional[SpeechHookManager] = None
+
+
+def getManager() -> SpeechHookManager:
+	"""Get the global SpeechHookManager instance."""
+	global _manager
+	if _manager is None:
+		_manager = SpeechHookManager()
+	return _manager
+
+
+def registerDefaultPatternRemovals() -> None:
+	"""Register the default patterns to be removed from the builtin dictionary."""
+	# These patterns are removed because they interfere with English text processing
+	# on Japanese synthesizers (e.g., camelCase word splitting)
+	extensionPoints.speechDictModifier.registerPatternRemoval("([a-z])([A-Z])")
+	extensionPoints.speechDictModifier.registerPatternRemoval("([A-Z])([A-Z][a-z])")

--- a/addon/globalPlugins/ERE/textProcessors.py
+++ b/addon/globalPlugins/ERE/textProcessors.py
@@ -1,9 +1,9 @@
 # coding: UTF-8
 """
-Text Processors Module for English Reading Enhancer
+English Reading Enhancer用のテキストプロセッサモジュール
 
-This module defines text processor classes that can be registered
-with the extension point system for text processing.
+このモジュールは、拡張ポイントシステムに登録できる
+テキストプロセッサクラスを定義します。
 """
 
 from __future__ import unicode_literals
@@ -14,46 +14,46 @@ from logHandler import log
 
 class TextProcessor(ABC):
 	"""
-	Abstract base class for text processors.
+	テキストプロセッサの抽象基底クラス。
 
-	Text processors transform text before it is passed to the speech
-	synthesizer. Each processor should implement the process method
-	and can optionally filter by locale.
+	テキストプロセッサは、音声合成器に渡される前にテキストを変換する。
+	各プロセッサはprocessメソッドを実装し、
+	オプションでロケールによるフィルタリングができる。
 	"""
 
 	def __init__(self, localePrefix: Optional[str] = None):
 		"""
-		Initialize the text processor.
+		テキストプロセッサを初期化する。
 
-		Args:
-			localePrefix: If set, only process text for locales starting with this prefix
+		引数:
+			localePrefix: 設定された場合、このプレフィックスで始まるロケールのテキストのみ処理する
 		"""
 		self._localePrefix = localePrefix
 
 	@abstractmethod
 	def process(self, text: str) -> str:
 		"""
-		Process the given text.
+		指定されたテキストを処理する。
 
-		Args:
-			text: The input text to process
+		引数:
+			text: 処理する入力テキスト
 
-		Returns:
-			The processed text
+		戻り値:
+			処理されたテキスト
 		"""
 		pass
 
 	def __call__(self, text: str, locale: str = "", **kwargs) -> str:
 		"""
-		Make the processor callable for use as an extension point handler.
+		プロセッサを拡張ポイントハンドラとして呼び出し可能にする。
 
-		Args:
-			text: The input text to process
-			locale: The locale of the text
-			**kwargs: Additional arguments (ignored)
+		引数:
+			text: 処理する入力テキスト
+			locale: テキストのロケール
+			**kwargs: 追加の引数（無視される）
 
-		Returns:
-			The processed text, or original text if locale doesn't match
+		戻り値:
+			処理されたテキスト、またはロケールが一致しない場合は元のテキスト
 		"""
 		if self._localePrefix and not locale.startswith(self._localePrefix):
 			return text
@@ -62,10 +62,10 @@ class TextProcessor(ABC):
 
 class EnglishToKanaProcessor(TextProcessor):
 	"""
-	Text processor that converts English text to Kana for Japanese speech synthesizers.
+	日本語音声合成器用に英語テキストをカナに変換するテキストプロセッサ。
 
-	This processor wraps the EnglishToKanaConverter and registers it with
-	the extension point system.
+	このプロセッサはEnglishToKanaConverterをラップし、
+	拡張ポイントシステムに登録する。
 	"""
 
 	def __init__(self):
@@ -73,7 +73,7 @@ class EnglishToKanaProcessor(TextProcessor):
 		self._converter = None
 
 	def _getConverter(self):
-		"""Lazy initialization of the converter."""
+		"""コンバータの遅延初期化。"""
 		if self._converter is None:
 			from ._englishToKanaConverter.englishToKanaConverter import EnglishToKanaConverter
 			self._converter = EnglishToKanaConverter()
@@ -81,13 +81,13 @@ class EnglishToKanaProcessor(TextProcessor):
 
 	def process(self, text: str) -> str:
 		"""
-		Convert English words in the text to Kana.
+		テキスト内の英単語をカナに変換する。
 
-		Args:
-			text: The input text potentially containing English words
+		引数:
+			text: 英単語を含む可能性のある入力テキスト
 
-		Returns:
-			Text with English words converted to Kana
+		戻り値:
+			英単語がカナに変換されたテキスト
 		"""
 		try:
 			return self._getConverter().process(text)
@@ -96,12 +96,12 @@ class EnglishToKanaProcessor(TextProcessor):
 			return text
 
 
-# Singleton instance for the English to Kana processor
+# EnglishToKanaプロセッサのシングルトンインスタンス
 _englishToKanaProcessor: Optional[EnglishToKanaProcessor] = None
 
 
 def getEnglishToKanaProcessor() -> EnglishToKanaProcessor:
-	"""Get the singleton EnglishToKanaProcessor instance."""
+	"""シングルトンのEnglishToKanaProcessorインスタンスを取得する。"""
 	global _englishToKanaProcessor
 	if _englishToKanaProcessor is None:
 		_englishToKanaProcessor = EnglishToKanaProcessor()

--- a/addon/globalPlugins/ERE/textProcessors.py
+++ b/addon/globalPlugins/ERE/textProcessors.py
@@ -1,0 +1,108 @@
+# coding: UTF-8
+"""
+Text Processors Module for English Reading Enhancer
+
+This module defines text processor classes that can be registered
+with the extension point system for text processing.
+"""
+
+from __future__ import unicode_literals
+from abc import ABC, abstractmethod
+from typing import Optional
+from logHandler import log
+
+
+class TextProcessor(ABC):
+	"""
+	Abstract base class for text processors.
+
+	Text processors transform text before it is passed to the speech
+	synthesizer. Each processor should implement the process method
+	and can optionally filter by locale.
+	"""
+
+	def __init__(self, localePrefix: Optional[str] = None):
+		"""
+		Initialize the text processor.
+
+		Args:
+			localePrefix: If set, only process text for locales starting with this prefix
+		"""
+		self._localePrefix = localePrefix
+
+	@abstractmethod
+	def process(self, text: str) -> str:
+		"""
+		Process the given text.
+
+		Args:
+			text: The input text to process
+
+		Returns:
+			The processed text
+		"""
+		pass
+
+	def __call__(self, text: str, locale: str = "", **kwargs) -> str:
+		"""
+		Make the processor callable for use as an extension point handler.
+
+		Args:
+			text: The input text to process
+			locale: The locale of the text
+			**kwargs: Additional arguments (ignored)
+
+		Returns:
+			The processed text, or original text if locale doesn't match
+		"""
+		if self._localePrefix and not locale.startswith(self._localePrefix):
+			return text
+		return self.process(text)
+
+
+class EnglishToKanaProcessor(TextProcessor):
+	"""
+	Text processor that converts English text to Kana for Japanese speech synthesizers.
+
+	This processor wraps the EnglishToKanaConverter and registers it with
+	the extension point system.
+	"""
+
+	def __init__(self):
+		super().__init__(localePrefix="ja")
+		self._converter = None
+
+	def _getConverter(self):
+		"""Lazy initialization of the converter."""
+		if self._converter is None:
+			from ._englishToKanaConverter.englishToKanaConverter import EnglishToKanaConverter
+			self._converter = EnglishToKanaConverter()
+		return self._converter
+
+	def process(self, text: str) -> str:
+		"""
+		Convert English words in the text to Kana.
+
+		Args:
+			text: The input text potentially containing English words
+
+		Returns:
+			Text with English words converted to Kana
+		"""
+		try:
+			return self._getConverter().process(text)
+		except Exception as e:
+			log.error(f"EnglishToKanaProcessor error: {e}")
+			return text
+
+
+# Singleton instance for the English to Kana processor
+_englishToKanaProcessor: Optional[EnglishToKanaProcessor] = None
+
+
+def getEnglishToKanaProcessor() -> EnglishToKanaProcessor:
+	"""Get the singleton EnglishToKanaProcessor instance."""
+	global _englishToKanaProcessor
+	if _englishToKanaProcessor is None:
+		_englishToKanaProcessor = EnglishToKanaProcessor()
+	return _englishToKanaProcessor


### PR DESCRIPTION
Replace direct function overrides with a clean extension point architecture:

- Add extensionPoints.py: Filter/Action classes for registering handlers
- Add textProcessors.py: TextProcessor base class and EnglishToKanaProcessor
- Add speechHook.py: SpeechHookManager for clean hook lifecycle management

This allows text processors to be registered/unregistered without
monkey-patching, making the code more maintainable and extensible.